### PR TITLE
Add SQL Server backend and CNN style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
-# codex-test01
+# Time Tracking App
 
-111
+This project is a minimal fullstack example with an Angular frontend and a .NET Core backend using SQL Server for persistence.
+
+## Backend
+
+The backend is located in `backend/TimeTrackingApi` and uses Entity Framework Core with SQL Server. It exposes the following endpoints:
+
+- `GET /api/projects` – list all projects
+- `POST /api/projects` – create a project
+- `GET /api/timeentries` – list all time entries
+- `POST /api/timeentries` – create a new entry
+
+Connection settings are provided in `backend/TimeTrackingApi/appsettings.json`. Update the `TimeTrackingDb` connection string to point to your SQL Server instance.
+
+Run the backend with:
+
+```bash
+dotnet run --project backend/TimeTrackingApi
+```
+
+## Frontend
+
+The frontend is an Angular application located in `frontend`.
+
+Install dependencies and start the dev server:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+API calls to `/api` are proxied to the backend running on the same host.

--- a/backend/TimeTrackingApi/Program.cs
+++ b/backend/TimeTrackingApi/Program.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
+});
+
+builder.Services.AddDbContext<TimeTrackingDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("TimeTrackingDb")));
+
+var app = builder.Build();
+app.UseCors();
+
+app.MapGet("/api/projects", async (TimeTrackingDbContext db) =>
+    await db.Projects.ToListAsync());
+
+app.MapPost("/api/projects", async (TimeTrackingDbContext db, Project project) =>
+{
+    db.Projects.Add(project);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/projects/{project.Id}", project);
+});
+
+app.MapGet("/api/timeentries", async (TimeTrackingDbContext db) =>
+    await db.TimeEntries.Include(e => e.Project).ToListAsync());
+
+app.MapPost("/api/timeentries", async (TimeTrackingDbContext db, TimeEntry entry) =>
+{
+    db.TimeEntries.Add(entry);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/timeentries/{entry.Id}", entry);
+});
+
+app.Run();
+
+public class TimeTrackingDbContext : DbContext
+{
+    public TimeTrackingDbContext(DbContextOptions<TimeTrackingDbContext> options)
+        : base(options) {}
+
+    public DbSet<Project> Projects => Set<Project>();
+    public DbSet<TimeEntry> TimeEntries => Set<TimeEntry>();
+}
+
+public class Project
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<TimeEntry> Entries { get; set; } = new();
+}
+
+public class TimeEntry
+{
+    public int Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Hours { get; set; }
+    public DateTime Date { get; set; }
+    public int ProjectId { get; set; }
+    public Project? Project { get; set; }
+}

--- a/backend/TimeTrackingApi/TimeTrackingApi.csproj
+++ b/backend/TimeTrackingApi/TimeTrackingApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/backend/TimeTrackingApi/appsettings.json
+++ b/backend/TimeTrackingApi/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "TimeTrackingDb": "Server=(localdb)\\MSSQLLocalDB;Database=TimeTracking;Trusted_Connection=True"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "time-tracking-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ng serve"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/router": "^17.0.0",
+    "rxjs": "~7.5.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.12.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.0.0",
+    "@angular/cli": "^17.0.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "typescript": "~5.0.0"
+  }
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,95 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+interface Project {
+  id: number;
+  name: string;
+}
+
+interface TimeEntry {
+  id: number;
+  description: string;
+  hours: number;
+  date: string;
+  projectId: number;
+  project?: Project;
+}
+
+@Component({
+  selector: 'app-root',
+  template: `
+  <header class="cnn-header">CNN Time Tracker</header>
+  <div class="container">
+    <form (submit)="addEntry()" class="entry-form">
+      <label>
+        Project
+        <select [(ngModel)]="projectId" name="projectId" required>
+          <option *ngFor="let p of projects" [value]="p.id">{{ p.name }}</option>
+        </select>
+      </label>
+      <label>
+        Description
+        <input [(ngModel)]="description" name="description" required>
+      </label>
+      <label>
+        Hours
+        <input type="number" step="0.25" [(ngModel)]="hours" name="hours" required>
+      </label>
+      <button type="submit">Add Entry</button>
+    </form>
+
+    <h2>Entries</h2>
+    <ul>
+      <li *ngFor="let entry of entries">
+        <strong>{{ entry.project?.name }}</strong>: {{ entry.description }} - {{ entry.hours }}h on {{ entry.date | date }}
+      </li>
+    </ul>
+  </div>
+  `,
+  styles: []
+})
+export class AppComponent implements OnInit {
+  projects: Project[] = [];
+  entries: TimeEntry[] = [];
+  description = '';
+  hours = 0.25;
+  projectId: number | null = null;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.loadProjects();
+    this.loadEntries();
+  }
+
+  loadProjects() {
+    this.http.get<Project[]>('/api/projects')
+      .subscribe(data => {
+        this.projects = data;
+        if (this.projects.length && this.projectId === null) {
+          this.projectId = this.projects[0].id;
+        }
+      });
+  }
+
+  loadEntries() {
+    this.http.get<TimeEntry[]>('/api/timeentries')
+      .subscribe(data => this.entries = data);
+  }
+
+  addEntry() {
+    if (this.projectId == null) return;
+    const entry = {
+      description: this.description,
+      hours: this.hours,
+      date: new Date().toISOString(),
+      projectId: this.projectId
+    };
+    this.http.post<TimeEntry>('/api/timeentries', entry)
+      .subscribe(() => {
+        this.description = '';
+        this.hours = 0.25;
+        this.loadEntries();
+      });
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, HttpClientModule, FormsModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Time Tracking</title>
+  <base href="/">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,29 @@
+body {
+  margin: 0;
+  font-family: Helvetica, Arial, sans-serif;
+  background-color: #fff;
+  color: #000;
+}
+
+.cnn-header {
+  background-color: #cc0000;
+  color: #fff;
+  padding: 10px 20px;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.container {
+  padding: 20px;
+}
+
+.entry-form label {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.entry-form input,
+.entry-form select {
+  padding: 4px;
+  margin-left: 5px;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2015",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
+  }
+}


### PR DESCRIPTION
## Summary
- switch backend to SQL Server using EF Core
- document new endpoints and connection string in README
- add appsettings.json with example connection string
- update Angular UI for projects and quarter-hour entries
- style the frontend similar to cnn.com

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*